### PR TITLE
Add Forge build task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,6 +81,27 @@ tasks.named("sourcesJar") {
         exclude "net/minecraftforge/**"
 }
 
+// Build a jar for Forge that excludes Fabric-specific metadata
+tasks.register("forgeJar", Jar) {
+        archiveClassifier.set("forge")
+        from sourceSets.main.output
+        from sourceSets.client.output
+
+        // Reuse license handling from the main jar
+        inputs.property "archivesName", project.base.archivesName
+        from("LICENSE") {
+                rename { "${it}_${inputs.properties.archivesName}" }
+        }
+
+        // Remove Fabric metadata from the Forge jar
+        exclude "fabric.mod.json"
+        exclude "net/minecraftforge/**"
+}
+
+tasks.named("build") {
+        dependsOn tasks.named("forgeJar")
+}
+
 // configure the maven publication
 publishing {
 	publications {


### PR DESCRIPTION
## Summary
- add a Gradle task to build a Forge-specific jar

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68a4717e81ac8322b9db0af4f2729bfb